### PR TITLE
Add mapping by field into json parser, fix action parsing

### DIFF
--- a/modules/core/src/main/scala/muffin/codec/CodecSupport.scala
+++ b/modules/core/src/main/scala/muffin/codec/CodecSupport.scala
@@ -49,6 +49,8 @@ trait JsonRequestBuilder[T, To[_]]() { self =>
 trait JsonResponseBuilder[From[_], Params <: Tuple] {
   def field[X: From](name: String): JsonResponseBuilder[From, X *: Params]
 
+  def fieldMap[X: From, B](name: String)(f: X => B): JsonResponseBuilder[From, B *: Params]
+
   def rawField(name: String): JsonResponseBuilder[From, Option[String] *: Params]
 
   def internal[X: From](name: String): JsonResponseBuilder[From, X *: Params]
@@ -586,7 +588,7 @@ trait CodecSupportLow[To[_], From[_]] extends PrimitivesSupport[To, From] {
 
   given AttachmentFrom: From[Attachment] =
     parsing
-      .field[List[Action]]("actions")
+      .fieldMap[Option[List[Action]], List[Action]]("actions")(_.getOrElse(Nil))
       .field[Option[String]]("footer_icon")
       .field[Option[String]]("footer")
       .field[Option[String]]("thumb_url")

--- a/modules/integration/circe-json-interop/src/main/scala/muffin/interop/json/circe/codec.scala
+++ b/modules/integration/circe-json-interop/src/main/scala/muffin/interop/json/circe/codec.scala
@@ -137,6 +137,9 @@ trait CodecLow2 extends CodecSupport[Encoder, Decoder] {
     def field[X: Decoder](name: String): JsonResponseBuilder[Decoder, X *: Decoders] =
       CirceResponseBuilder[X *: Decoders](decoders.flatMap(all => Decoder[X].at(name).map(_ *: all)))
 
+    def fieldMap[X: Decoder, B](name: String)(f: X => B): JsonResponseBuilder[Decoder, B *: Decoders] =
+      CirceResponseBuilder[B *: Decoders](decoders.flatMap(all => Decoder[X].at(name).map(x => f(x) *: all)))
+
     def rawField(name: String): JsonResponseBuilder[Decoder, Option[String] *: Decoders] =
       CirceResponseBuilder[Option[String] *: Decoders] {
         decoders.flatMap(all =>

--- a/modules/integration/zio-json-interop/src/main/scala/muffin/interop/json/zio/codec.scala
+++ b/modules/integration/zio-json-interop/src/main/scala/muffin/interop/json/zio/codec.scala
@@ -124,6 +124,12 @@ trait CodecLow extends CodecSupport[JsonEncoder, JsonDecoder] {
         summon[JsonDecoder[X]].asInstanceOf[JsonDecoder[Any]] :: decoders
       )
 
+    def fieldMap[X: JsonDecoder, B](name: String)(f: X => B): JsonResponseBuilder[JsonDecoder, B *: Params] =
+      new ZioResponseBuilder[B *: Params](
+        name :: stateNames,
+        summon[JsonDecoder[X]].map(f).asInstanceOf[JsonDecoder[Any]] :: decoders
+      )
+
     override def internal[X: JsonDecoder](name: String): JsonResponseBuilder[JsonDecoder, X *: Params] =
       new ZioResponseBuilder[X *: Params](
         name :: stateNames,


### PR DESCRIPTION
Improve usability of JsonResponseBuilder adding fieldlMap that allows to map field in-place. Fix using of ___actions___ field in Attachment class