### PR TITLE
Fix macros, MessageAction parsing

### DIFF
--- a/modules/core/src/main/scala/muffin/codec/CodecSupport.scala
+++ b/modules/core/src/main/scala/muffin/codec/CodecSupport.scala
@@ -423,7 +423,7 @@ trait CodecSupportLow[To[_], From[_]] extends PrimitivesSupport[To, From] {
       .field[Option[String]]("callback_id")
       .build(DialogAction[T].apply.tupled)
 
-  given MessageActionFrom[T: From]: From[MessageAction[T]] =
+  given MessageActionFrom[T: From]: From[MessageAction.Raw[T]] =
     parsing
       .field[Option[T]]("context")
       .field[String]("type")
@@ -436,29 +436,14 @@ trait CodecSupportLow[To[_], From[_]] extends PrimitivesSupport[To, From] {
       .field[ChannelId]("channel_id")
       .field[Login]("user_name")
       .field[UserId]("user_id")
-      .build {
-        case userId *: userName *: channelId *: channelName *: teamId *: teamDomain *: postId *: trigger *: data *: typ *: context *: EmptyTuple =>
-          MessageAction(
-            userId,
-            userName,
-            channelId,
-            channelName,
-            teamId,
-            teamDomain,
-            postId,
-            trigger,
-            data,
-            typ,
-            context.getOrElse(().asInstanceOf[Nothing])
-          )
-      }
+      .build(MessageAction.Raw[T].apply.tupled)
 
   given AppResponseTo: To[AppResponse] =
     seal {
       case AppResponse.Ok()                                     =>
         json[AppResponse]
           .build
-      case AppResponse.Message(text, responseType, attachments) =>
+      case AppResponse.Message(responseType, text, attachments) =>
         json[AppResponse]
           .field("text", _ => text)
           .field("response_type", _ => responseType)

--- a/modules/core/src/main/scala/muffin/internal/router/RouterDSL.scala
+++ b/modules/core/src/main/scala/muffin/internal/router/RouterDSL.scala
@@ -43,11 +43,32 @@ object Handle {
         )
       }
 
-    transparent inline def action[In](
-        inline value: H => MessageAction[In] => F[AppResponse]
+    transparent inline def actionWithNoContext(
+        inline value: H => MessageAction.NoContext => F[AppResponse]
+    ): Handle[F, H, N, CommandName, ? <: Tuple, Nothing *: ActionIn, DialogName, DialogIn] =
+      ${
+        Handle.actionWithNoContext[
+          F,
+          H,
+          N,
+          CommandName,
+          ActionName,
+          ActionIn,
+          DialogName,
+          DialogIn,
+        ](
+          'value,
+          '{
+            h.h
+          }
+        )
+      }
+
+    transparent inline def actionWithContext[In](
+        inline value: H => MessageAction.Context[In] => F[AppResponse]
     ): Handle[F, H, N, CommandName, ? <: Tuple, In *: ActionIn, DialogName, DialogIn] =
       ${
-        Handle.action[
+        Handle.actionWithContext[
           F,
           H,
           N,
@@ -125,9 +146,33 @@ object Handle {
     }
   }
 
-  def action[F[_]
+  def actionWithNoContext[F[_]
+    : Type, H: Type, N <: Singleton: Type, CommandName <: Tuple: Type, ActionName <: Tuple: Type, ActionIn <: Tuple: Type, DialogName <: Tuple: Type, DialogIn <: Tuple: Type](
+      fun: Expr[H => MessageAction.NoContext => F[AppResponse]],
+      handle: Expr[H]
+  )(using Quotes) = {
+    import quotes.reflect.*
+
+    functionName(fun.asTerm.underlying) match {
+      case '[name] =>
+        '{
+          Handle[
+            F,
+            H,
+            N,
+            CommandName,
+            name *: ActionName,
+            Nothing *: ActionIn,
+            DialogName,
+            DialogIn
+          ]($handle)
+        }
+    }
+  }
+
+  def actionWithContext[F[_]
     : Type, H: Type, N <: Singleton: Type, In: Type, CommandName <: Tuple: Type, ActionName <: Tuple: Type, ActionIn <: Tuple: Type, DialogName <: Tuple: Type, DialogIn <: Tuple: Type](
-      fun: Expr[H => MessageAction[In] => F[AppResponse]],
+      fun: Expr[H => MessageAction.Context[In] => F[AppResponse]],
       handle: Expr[H]
   )(using Quotes) = {
     import quotes.reflect.*

--- a/modules/core/src/main/scala/muffin/model/Actions.scala
+++ b/modules/core/src/main/scala/muffin/model/Actions.scala
@@ -2,19 +2,50 @@ package muffin.model
 
 import cats.syntax.all.given
 
-case class MessageAction[T](
-    userId: UserId,
-    userName: Login,
-    channelId: ChannelId,
-    channelName: String,
-    teamId: TeamId,
-    teamDomain: String,
-    postId: MessageId,
-    triggerId: String,
-    dataSource: String,
-    `type`: String,
-    context: T
-)
+object MessageAction {
+
+  private[muffin] case class Raw[T](
+      userId: UserId,
+      userName: Login,
+      channelId: ChannelId,
+      channelName: String,
+      teamId: TeamId,
+      teamDomain: String,
+      postId: MessageId,
+      triggerId: String,
+      dataSource: String,
+      `type`: String,
+      context: Option[T]
+  )
+
+  case class Context[T](
+      userId: UserId,
+      userName: Login,
+      channelId: ChannelId,
+      channelName: String,
+      teamId: TeamId,
+      teamDomain: String,
+      postId: MessageId,
+      triggerId: String,
+      dataSource: String,
+      `type`: String,
+      context: T
+  )
+
+  case class NoContext(
+      userId: UserId,
+      userName: Login,
+      channelId: ChannelId,
+      channelName: String,
+      teamId: TeamId,
+      teamDomain: String,
+      postId: MessageId,
+      triggerId: String,
+      dataSource: String,
+      `type`: String
+  )
+
+}
 
 case class CommandAction(
     channelId: ChannelId,


### PR DESCRIPTION
Fix macros: update model generation that depends on context existing.
Fix MessageAction parsing: create explicit models with and without context, add parser to it in macro